### PR TITLE
Add support for request.xhr? Rails method.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import axios from 'axios'
 import { csrfToken } from 'rails-ujs'
 
 axios.defaults.headers.common['X-CSRF-Token'] = csrfToken()
+axios.defaults.headers.common['X-Requested-With'] = "XMLHttpRequest"
 
 export default axios


### PR DESCRIPTION
Currently, in order to check if the request was an AJAX call, you have to set the `X-Requested-With` header to "XMLHttpRequest". This simply adds that as a default.